### PR TITLE
Update Docker build and push actions

### DIFF
--- a/.github/workflows/cloud-run.yml
+++ b/.github/workflows/cloud-run.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Authenticate with Google Cloud
       - id: "auth"
-        uses: "google-github-actions/auth@v0"
+        uses: "google-github-actions/auth@v2"
         with:
           credentials_json: "${{ secrets.CLOUD_RUN_SERVICE_ACCOUNT }}"
 
@@ -31,17 +31,9 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
 
-      - name: Authorize Docker push
-        run: gcloud auth configure-docker
-
-      - name: Build and tag the docker image
+      - name: Build and push the Docker image
         run: |-
-          docker build . --tag $REGION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME:$GITHUB_SHA
-          
-
-      - name: Push the image to the Google Artifact Registry
-        run: |-
-          docker push $REGION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME:$GITHUB_SHA
+          gcloud builds submit --region $REGION --tag $REGION-docker.pkg.dev/$PROJECT_ID/$REPO_NAME:$GITHUB_SHA
 
       - name: Deploy
         run: |-


### PR DESCRIPTION
This pull request updates the Docker build and push actions in the GitHub Actions workflow. It replaces the deprecated `actions/checkout@v3` with `actions/checkout@v4` and updates the `google-github-actions/auth` action to version 2. Additionally, it replaces the `docker build` and `docker push` commands with `gcloud builds submit` for building and pushing the Docker image to the Google Artifact Registry.