### PR TITLE
Add region flag to update-traffic command

### DIFF
--- a/.github/workflows/cloud-run.yml
+++ b/.github/workflows/cloud-run.yml
@@ -51,5 +51,6 @@ jobs:
           --quiet \
           && gcloud run services update-traffic $SERVICE_NAME \
           --to-latest \
+          --region $SERVICE_REGION
 
 


### PR DESCRIPTION
This pull request adds a region flag to the update-traffic command in order to specify the region for the service update. This allows for more granular control over the deployment process.